### PR TITLE
Block model config UI when using Azure OpenAI to eliminate ambiguity

### DIFF
--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -13,15 +13,29 @@ import EyeIcon from "../icons/eye.svg";
 import CopyIcon from "../icons/copy.svg";
 
 import { DEFAULT_MASK_AVATAR, Mask, useMaskStore } from "../store/mask";
-import { ChatMessage, ModelConfig, useAppConfig, useChatStore } from "../store";
+import {
+  ChatMessage,
+  ModelConfig,
+  useAccessStore,
+  useAppConfig,
+  useChatStore,
+} from "../store";
 import { ROLES } from "../client/api";
-import { Input, List, ListItem, Modal, Popover, Select } from "./ui-lib";
+import {
+  Input,
+  List,
+  ListItem,
+  Modal,
+  Popover,
+  Select,
+  TextInput,
+} from "./ui-lib";
 import { Avatar, AvatarPicker } from "./emoji";
 import Locale, { AllLangs, ALL_LANG_OPTIONS, Lang } from "../locales";
 import { useNavigate } from "react-router-dom";
 
 import chatStyle from "./chat.module.scss";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { downloadAs, readFromFile } from "../utils";
 import { Updater } from "../typing";
 import { ModelConfigList } from "./model-config";
@@ -58,6 +72,8 @@ export function MaskConfig(props: {
   };
 
   const globalConfig = useAppConfig();
+
+  const accessStore = useAccessStore();
 
   return (
     <>
@@ -140,6 +156,17 @@ export function MaskConfig(props: {
           </ListItem>
         ) : null}
       </List>
+
+      {accessStore.enableAOAI ? (
+        <List>
+          <ListItem
+            title={Locale.Settings.AzureDeploymentName.Title}
+            subTitle={Locale.Settings.AzureDeploymentName.SubTitle}
+          >
+            <TextInput value={accessStore.azureDeployName} />
+          </ListItem>
+        </List>
+      ) : null}
 
       <List>
         <ModelConfigList

--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -1,34 +1,44 @@
-import { ALL_MODELS, ModalConfigValidator, ModelConfig } from "../store";
+import {
+  ALL_MODELS,
+  ModalConfigValidator,
+  ModelConfig,
+  useAccessStore,
+} from "../store";
 
 import Locale from "../locales";
 import { InputRange } from "./input-range";
-import { List, ListItem, Select } from "./ui-lib";
+import { ListItem, Select } from "./ui-lib";
 
 export function ModelConfigList(props: {
   modelConfig: ModelConfig;
   updateConfig: (updater: (config: ModelConfig) => void) => void;
 }) {
+  const accessStore = useAccessStore();
+
   return (
     <>
-      <ListItem title={Locale.Settings.Model}>
-        <Select
-          value={props.modelConfig.model}
-          onChange={(e) => {
-            props.updateConfig(
-              (config) =>
-                (config.model = ModalConfigValidator.model(
-                  e.currentTarget.value,
-                )),
-            );
-          }}
-        >
-          {ALL_MODELS.map((v) => (
-            <option value={v.name} key={v.name} disabled={!v.available}>
-              {v.name}
-            </option>
-          ))}
-        </Select>
-      </ListItem>
+      {accessStore.enableAOAI ? null : (
+        <ListItem title={Locale.Settings.Model}>
+          <Select
+            value={props.modelConfig.model}
+            onChange={(e) => {
+              props.updateConfig(
+                (config) =>
+                  (config.model = ModalConfigValidator.model(
+                    e.currentTarget.value,
+                  )),
+              );
+            }}
+          >
+            {ALL_MODELS.map((v) => (
+              <option value={v.name} key={v.name} disabled={!v.available}>
+                {v.name}
+              </option>
+            ))}
+          </Select>
+        </ListItem>
+      )}
+
       <ListItem
         title={Locale.Settings.Temperature.Title}
         subTitle={Locale.Settings.Temperature.SubTitle}


### PR DESCRIPTION
This PR is to block the model config UI, which contains a list of models to choose, to eliminate the ambiguous experience for users when using Azure OpenAI Services.

Changed file:

* app/components/model-config.tsx
* app/components/mask.tsx