### PR TITLE
Enable editing deploy name for each chat session

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -20,11 +20,13 @@ export class ChatGPTApi implements LLMApi {
 
   public get ChatPath() {
     const OPENAI_REQUEST_PATH = "v1/chat/completions";
-    const { enableAOAI, azureDeployName } = useAccessStore.getState();
+    const enableAOAI = useAccessStore.getState();
     if (!enableAOAI) return OPENAI_REQUEST_PATH;
 
     // For now azure api only support one version
     const azureApiVersion = AZURE_API_VERSION[0].name;
+    const azureDeployName = useChatStore.getState().currentSession()
+      .mask.azureDeployName;
 
     const AZURE_REQUEST_PATH = `openai/deployments/${azureDeployName}/chat/completions?api-version=${azureApiVersion}`;
     return AZURE_REQUEST_PATH;

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -148,6 +148,8 @@ export function MaskConfig(props: {
                 ) {
                   props.updateMask((mask) => {
                     mask.syncGlobalConfig = e.currentTarget.checked;
+                    mask.azureDeployName =
+                      useAccessStore.getState().azureDeployName;
                     mask.modelConfig = { ...globalConfig.modelConfig };
                   });
                 }
@@ -163,7 +165,16 @@ export function MaskConfig(props: {
             title={Locale.Settings.AzureDeploymentName.Title}
             subTitle={Locale.Settings.AzureDeploymentName.SubTitle}
           >
-            <TextInput value={accessStore.azureDeployName} />
+            <input
+              type="text"
+              value={props.mask.azureDeployName}
+              onInput={(e) => {
+                props.updateMask((mask) => {
+                  mask.azureDeployName = e.currentTarget.value;
+                  mask.syncGlobalConfig = false;
+                });
+              }}
+            ></input>
           </ListItem>
         </List>
       ) : null}

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -38,6 +38,8 @@ export const DEFAULT_CONFIG = {
     historyMessageCount: 4,
     compressMessageLengthThreshold: 1000,
   },
+
+  azureDeployName: "",
 };
 
 export type ChatConfig = typeof DEFAULT_CONFIG;

--- a/app/store/mask.ts
+++ b/app/store/mask.ts
@@ -3,8 +3,9 @@ import { persist } from "zustand/middleware";
 import { BUILTIN_MASKS } from "../masks";
 import { getLang, Lang } from "../locales";
 import { DEFAULT_TOPIC, ChatMessage } from "./chat";
-import { ModelConfig, ModelType, useAppConfig } from "./config";
+import { ModelConfig, useAppConfig } from "./config";
 import { StoreKey } from "../constant";
+import { useAccessStore } from "./access";
 
 export type Mask = {
   id: number;
@@ -14,6 +15,7 @@ export type Mask = {
   context: ChatMessage[];
   syncGlobalConfig?: boolean;
   modelConfig: ModelConfig;
+  azureDeployName: string;
   lang: Lang;
   builtin: boolean;
 };
@@ -43,6 +45,7 @@ export const createEmptyMask = () =>
     context: [],
     syncGlobalConfig: true, // use global config as default
     modelConfig: { ...useAppConfig.getState().modelConfig },
+    azureDeployName: useAccessStore.getState().azureDeployName,
     lang: getLang(),
     builtin: false,
   } as Mask);


### PR DESCRIPTION
This PR is to enable users to edit the deploy names of their Azure OpenAI models for each chat session.

Known issue (bug):

* When the global deploy name changed, the chat sessions using global configs will not change their deploy name.