### PR TITLE
fix: update endpoint url check

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,7 +24,7 @@ jobs:
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
         with:
-          upstream_sync_repo: Yidadaa/ChatGPT-Next-Web
+          upstream_sync_repo: realDuang/ChatGPT-Next-Web
           upstream_sync_branch: main
           target_sync_branch: main
           target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set

--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -49,7 +49,7 @@ export async function requestOpenai(req: NextRequest) {
   };
 
   const AZURE_ENDPOINT = process.env.AZURE_ENDPOINT;
-  if (!!AZURE_ENDPOINT && AZURE_ENDPOINT.endsWith("openai.azure.com")) {
+  if (!!AZURE_ENDPOINT && /openai\.azure\.com\/?$/.test(AZURE_ENDPOINT)) {
     const AZURE_API_KEY = process.env.AZURE_API_KEY;
     const AZURE_DEPLOY_NAME = process.env.AZURE_DEPLOY_NAME;
 


### PR DESCRIPTION
fixed a bug: server config won't take effects if the value of AZURE_ENDPOINT ends with a `/`(which is most of the cases when copied from MS Azure).

